### PR TITLE
Bug: Search filter filter was not returning pokemon #1

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,7 +13,7 @@ const HomePage: React.FC = () => {
     });
 
     searchTerm === '' ? setPokemon(pokemonData) : setPokemon(foundPoke);
-  }, []);
+  }, [searchTerm]);
 
   // useEffect(()=>{},[])
 


### PR DESCRIPTION
## Changes
1. Updated searchTerm  by calling on searchTerm at the end.

## Purpose
Updated to render pokemon to match the string characters in the search input via calling searchTerm.

## Approach
By adding searchTerm in [ ]); the characters entered in the search input are able to be used to pull a pokemon with similar characters. 

## Learning
We learned on the previous session that in order to have the characters in the search input take effect the function must be called upon.