### PR TITLE
Bug: Console error on Single Pokemon page #4

### DIFF
--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -112,7 +112,7 @@ const SinglePokemonPage: React.FC = () => {
                     <div className='row'>
                       {pokemon.prev_evolution?.map((pe, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col' key={i}>
                             <h5 className='text-secondary'>
                               Previous Evolution
                             </h5>
@@ -127,7 +127,7 @@ const SinglePokemonPage: React.FC = () => {
                       })}
                       {pokemon.next_evolution?.map((ne, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col' key={i}>
                             <h5 className='text-secondary'>Next Evolution</h5>
                             <div>
                               <Link to={`/pokemon/${ne.name.toLowerCase()}`}>


### PR DESCRIPTION
## Changes
1. Added key={i} to the previous evolution and next evolution map.
## Purpose
To give an identity to the previous evolution and next evolution pokemon being maped.
## Approach
Used the key={i} in the parent div of the previous and next evolution after checking the rest of the things that were being rendered.
## Learning
We learned about the key special attribute during our sessions, and using it to identify items after being included when creating lists of elements that are either changed, updated or removed.
